### PR TITLE
Refactors target path resolution for apps

### DIFF
--- a/src/qlik/cicd/core.clj
+++ b/src/qlik/cicd/core.clj
@@ -3,8 +3,7 @@
 (ns qlik.cicd.core
   (:require [qlik.cicd.utilities :as utilities]
             [qlik.cicd.api :as api]
-            [clojure.string :as string]
-            [clojure.java.io :as io]))
+            [clojure.string :as string]))
 
 (defn pull
   ([env app-name source-space]
@@ -12,12 +11,7 @@
   ([env app-name source-space target-space]
    (if (utilities/app-exists? env app-name source-space)
      (let [app-id (utilities/get-app-id env app-name source-space)
-           project-path (:project-path env)
-           _ (when-not project-path
-               (throw (ex-info "Project path is required" {:env env})))
-           
-           target-path (str project-path "/spaces/" target-space "/apps/" app-name "/") 
-           _ (clojure.java.io/make-parents (str target-path "placeholder"))]
+           target-path (utilities/get-target-path env app-id target-space)]
        
        (utilities/unbuild-app env app-id target-path))
      

--- a/test/qlik/cicd/utilities_test.clj
+++ b/test/qlik/cicd/utilities_test.clj
@@ -153,3 +153,24 @@
   (test/is (thrown-with-msg? clojure.lang.ExceptionInfo
                            #"app-id cannot be nil"
                            (utilities/is-script-app? env nil))))
+
+(test/deftest test-get-app-name
+  (test/testing "Returns app name for valid app-id"
+    (with-redefs [api/get-items (fn [_ params]
+                                  (test/is (= (:resource-id params) "app-123"))
+                                  (test/is (= (:resource-type params) "app"))
+                                  [{:id "app-123" :name "Test App"}])]
+      (test/is (= "Test App" (utilities/get-app-name env "app-123")))))
+  
+  (test/testing "Returns nil for non-existent app"
+    (with-redefs [api/get-items (fn [_ params]
+                                  (test/is (= (:resource-id params) "non-existent"))
+                                  (test/is (= (:resource-type params) "app"))
+                                  [])]
+      (test/is (nil? (utilities/get-app-name env "non-existent")))))
+  
+  (test/testing "Throws exception when app-id is nil"
+    (test/is (thrown-with-msg?
+              clojure.lang.ExceptionInfo
+              #"app-id cannot be nil"
+              (utilities/get-app-name env nil)))))


### PR DESCRIPTION
Improves the app pulling process by:

- Introduces `get-target-path` function to encapsulate target path resolution.
- Uses app ID to determine the application name, ensuring correct target directory.
- Adds support for script apps, placing them in a dedicated "scripts" directory.
- Improves error handling.